### PR TITLE
Remove fields casting for signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Send event:
     event_group_id: 'eb2bc8bb-f584-4801-b98c-361a0c2d38f8',
     event_id: 'ed62d0c1-f2a5-41b7-ab58-24c033eec508',,
   }
-  client.ingest(event)
+  client.ingest(**event)
 ```
 
 Event attributes:

--- a/lib/ubersicht/ingestion/client.rb
+++ b/lib/ubersicht/ingestion/client.rb
@@ -32,7 +32,7 @@ module Ubersicht
       def ingest(transaction_type:, event_code:, event_date: Time.now, **payload)
         event = {
           event_code: event_code,
-          event_date: event_date,
+          event_date: event_date.iso8601(3),
           payload: payload,
           transaction_type: transaction_type
         }

--- a/lib/ubersicht/ingestion/event.rb
+++ b/lib/ubersicht/ingestion/event.rb
@@ -6,7 +6,7 @@ module Ubersicht
 
     class Event < ::Dry::Struct
       attribute :event_code, Types::String
-      attribute :event_date, Types::Time || Types::DateTime
+      attribute :event_date, Types::String
       attribute :transaction_type, Types::String # DeviceBinding
       attribute :payload, Types::Hash.optional.default({}.freeze)
       # payload.event_date

--- a/lib/ubersicht/ingestion/hmac_validator.rb
+++ b/lib/ubersicht/ingestion/hmac_validator.rb
@@ -27,17 +27,11 @@ module Ubersicht
       end
 
       def self.with_ubersicht
-        transform_value_fn = lambda do |value|
-          next value.to_i if value.respond_to?(:strftime)
-
-          value
-        end
-        new(UBERSICHT_HMAC_SIGNATURE_PATH, UBERSICHT_VALIDATION_KEYS, transform_value_fn: transform_value_fn)
+        new(UBERSICHT_HMAC_SIGNATURE_PATH, UBERSICHT_VALIDATION_KEYS)
       end
 
-      def initialize(hmac_signature_path, validation_keys, transform_value_fn: :itself.to_proc)
+      def initialize(hmac_signature_path, validation_keys)
         @hmac_signature_path = hmac_signature_path
-        @transform_value_fn = transform_value_fn
         @validation_keys = validation_keys
       end
 
@@ -49,7 +43,7 @@ module Ubersicht
 
       def data_to_sign(notification_request_item)
         validation_keys
-          .map { |key| transform_value_fn.call(fetch(notification_request_item, key)).to_s }
+          .map { |key| fetch(notification_request_item, key).to_s }
           .map { |value| value.gsub('\\', '\\\\').gsub(':', '\\:') }
           .join(DATA_SEPARATOR)
       end
@@ -71,7 +65,6 @@ module Ubersicht
 
       attr_reader \
         :hmac_signature_path,
-        :transform_value_fn,
         :validation_keys
 
       def fetch(hash, keys)

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -3,7 +3,7 @@ module TestHelpers
     def ingestion_event(attrs = {})
       defaults = {
         event_code: 'some-code',
-        event_date: Time.now.round,
+        event_date: Time.now.round.iso8601(3),
         transaction_type: 'DeviceBinding'
         # payload: {
         #   event_group_id: 'some-transaction-id',

--- a/spec/ubersicht/ingestion/hmac_validator_spec.rb
+++ b/spec/ubersicht/ingestion/hmac_validator_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Ubersicht::Ingestion::HmacValidator do
     subject(:validator) { described_class.with_ubersicht }
 
     let(:key) { '44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056' }
-    let(:expected_sign) { 'Bzkje8mvjdLcWkDaY98Vd3ytywfeNVEaDgaTjpscTjo=' }
+    let(:expected_sign) { 'K4kwg9bCC9RiQsluvTBjZ6m1FKsVA7gGR6byCfJrQ/E=' }
     let(:notification_request_item) do
       {
         payload: {
@@ -75,15 +75,16 @@ RSpec.describe Ubersicht::Ingestion::HmacValidator do
           hmac_signature: expected_sign
         },
         event_code: 'requested',
-        event_date: Time.parse('2021-05-05 10:00:55'),
+        event_date: Time.parse('2021-05-05 10:00:55.011'),
         transaction_type: 'Authentication'
       }
     end
 
     describe '.data_to_sign' do
       it 'gets correct data' do
-        data_to_sign = validator.data_to_sign(notification_request_item)
-        expect(data_to_sign).to eq 'some-event-group-id:some-event-id:Authentication:requested:1620208855'
+        actual = validator.data_to_sign(notification_request_item)
+        expected = 'some-event-group-id:some-event-id:Authentication:requested:2021-05-05 10\\:00\\:55 +0000'
+        expect(actual).to eq(expected)
       end
     end
 


### PR DESCRIPTION
* [fix] remove date casting for signature, instead we cast date to string in the event. It leads to static signature on client and server side 